### PR TITLE
Improve cross-platform file handling

### DIFF
--- a/PSXDLL/AppConfig.cs
+++ b/PSXDLL/AppConfig.cs
@@ -1,4 +1,7 @@
-﻿namespace PSXDLL
+﻿using System;
+using System.IO;
+
+namespace PSXDLL
 {
     public class AppConfig
     {
@@ -35,7 +38,8 @@
         /// <summary>
         /// Local replacement directory
         /// </summary>
-        public string? LocalFileDirectory { get; set; } = "D:\\PSXDownloader";
+        public string? LocalFileDirectory { get; set; } =
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "PSXDownloader");
 
         /// <summary>
         /// Size of Buffer for Transfer Data

--- a/PSXDLL/HashUrl.cs
+++ b/PSXDLL/HashUrl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 
 namespace PSXDLL
 {
@@ -40,7 +41,7 @@ namespace PSXDLL
                 string filename = GetUrlFileName(psnurl);
                 if (!string.IsNullOrEmpty(filename))
                 {
-                    return AppConfig.Instance().LocalFileDirectory + "\\" + filename;
+                    return Path.Combine(AppConfig.Instance().LocalFileDirectory ?? string.Empty, filename);
                 }
 
                 return string.Empty;

--- a/PSXDownloader/MVVM/Data/PSXRepository.cs
+++ b/PSXDownloader/MVVM/Data/PSXRepository.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
-using WinForm = System.Windows.Forms;
+using Microsoft.Win32;
 
 namespace PSXDownloader.MVVM.Data
 {
@@ -106,22 +106,34 @@ namespace PSXDownloader.MVVM.Data
 
         public string? LocalFilePath()
         {
-            string? path = null;
-            WinForm.FolderBrowserDialog fbd = new();
-            if (fbd.ShowDialog() == WinForm.DialogResult.OK)
+            OpenFileDialog ofd = new()
             {
-                path = fbd.SelectedPath;
+                CheckFileExists = false,
+                CheckPathExists = true,
+                FileName = "Select Folder"
+            };
+
+            bool? result = ofd.ShowDialog();
+            if (result == true)
+            {
+                return Path.GetDirectoryName(ofd.FileName);
             }
-            return path;
+            return null;
         }
 
         public async Task<PSXDatabase?> SingleAdd()
         {
             string? path = null;
-            WinForm.FolderBrowserDialog fbd = new();
-            if (fbd.ShowDialog() == WinForm.DialogResult.OK)
+            OpenFileDialog ofd = new()
             {
-                path = fbd.SelectedPath;
+                CheckFileExists = false,
+                CheckPathExists = true,
+                FileName = "Select Folder"
+            };
+            bool? result = ofd.ShowDialog();
+            if (result == true)
+            {
+                path = Path.GetDirectoryName(ofd.FileName);
             }
 
             if (!string.IsNullOrEmpty(path))
@@ -167,7 +179,7 @@ namespace PSXDownloader.MVVM.Data
                 JsonSerializerOptions? options = new() { WriteIndented = true };
                 string? json = JsonSerializer.Serialize(entities, options);
                 string time = TimeOnly.FromDateTime(DateTime.Now).ToString().Replace(":", "-");
-                string backup = $"Backup\\{time}.json";
+                string backup = Path.Combine("Backup", $"{time}.json");
                 using StreamWriter sw = new(backup);
                 sw.WriteLine(json);
                 MessageBox.Show("Done");
@@ -184,12 +196,13 @@ namespace PSXDownloader.MVVM.Data
             {
                 Directory.CreateDirectory("Backup");
             }
-            WinForm.OpenFileDialog ofd = new()
+            OpenFileDialog ofd = new()
             {
                 Filter = "Json files (*.*)|*.json",
-                InitialDirectory = "Backup\\Game",
+                InitialDirectory = Path.Combine("Backup", "Game"),
             };
-            if (ofd.ShowDialog() == WinForm.DialogResult.OK)
+            bool? res = ofd.ShowDialog();
+            if (res == true)
             {
                 string? json = File.ReadAllText(ofd.FileName);
                 try

--- a/PSXDownloader/MVVM/Data/SettingRepository.cs
+++ b/PSXDownloader/MVVM/Data/SettingRepository.cs
@@ -1,7 +1,7 @@
 ﻿using PSXDLL;
 using System.IO;
 using System.Text.Json;
-using WinForm = System.Windows.Forms;
+using Microsoft.Win32;
 
 namespace PSXDownloader.MVVM.Data
 {
@@ -9,13 +9,19 @@ namespace PSXDownloader.MVVM.Data
     {
         public string? LocalFilePath()
         {
-            string? path = null;
-            WinForm.FolderBrowserDialog fbd = new();
-            if (fbd.ShowDialog() == WinForm.DialogResult.OK)
+            OpenFileDialog ofd = new()
             {
-                path = fbd.SelectedPath;
+                CheckFileExists = false,
+                CheckPathExists = true,
+                FileName = "Select Folder"
+            };
+
+            bool? result = ofd.ShowDialog();
+            if (result == true)
+            {
+                return Path.GetDirectoryName(ofd.FileName);
             }
-            return path;
+            return null;
         }
 
         public void SaveSetting(AppConfig? config)
@@ -25,7 +31,7 @@ namespace PSXDownloader.MVVM.Data
                 Directory.CreateDirectory("Settings");
             }
 
-            string? fileName = "Settings\\Settings.json";
+            string fileName = Path.Combine("Settings", "Settings.json");
             JsonSerializerOptions? options = new() { WriteIndented = true };
             string jsonString = JsonSerializer.Serialize(config, options);
             File.WriteAllText(fileName, jsonString);
@@ -33,7 +39,7 @@ namespace PSXDownloader.MVVM.Data
 
         public void LoadSetting(AppConfig? config)
         {
-            string? fileName = "Settings\\Settings.json";
+            string fileName = Path.Combine("Settings", "Settings.json");
             if (!File.Exists(fileName))
             {
                 SaveSetting(config);

--- a/PSXDownloader/MVVM/Models/PSXDataContext.cs
+++ b/PSXDownloader/MVVM/Models/PSXDataContext.cs
@@ -19,7 +19,8 @@ namespace PSXDownloader.MVVM.Models
             {
                 Directory.CreateDirectory("Database");
             }
-            optionsBuilder.UseSqlite(@"Data Source=Database\\PSXDatabase.db");
+            string dbPath = Path.Combine("Database", "PSXDatabase.db");
+            optionsBuilder.UseSqlite($"Data Source={dbPath}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove Windows Forms dialogs and use `Microsoft.Win32` dialogs
- build paths with `Path.Combine`
- default save location now resolves inside the user profile

## Testing
- `dotnet build PSXDownloader.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68557a508c608328b862bf9c11450f03