### PR TITLE
Fix BulkAdd directory check

### DIFF
--- a/PSXDownloader/MVVM/Data/PSXRepository.cs
+++ b/PSXDownloader/MVVM/Data/PSXRepository.cs
@@ -26,7 +26,7 @@ namespace PSXDownloader.MVVM.Data
         }
         public async Task BulkAdd(string? path)
         {
-            if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(path))
+            if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
             {
                 return;
             }


### PR DESCRIPTION
## Summary
- ensure `BulkAdd` returns early when the supplied directory is missing

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685647a9462083289a41e4e44e68a4c8